### PR TITLE
Chore - Bump minor version (6.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/react-native-mapbox-gl",
   "description": "A Mapbox GL react native module for creating custom maps",
-  "version": "6.1.4",
+  "version": "6.2.0",
   "author": "Bobby Sudekum",
   "main": "./javascript/index.js",
   "keywords": [


### PR DESCRIPTION
Following https://github.com/robinpowered/react-native-mapbox-gl/pull/1, we'll bump the version to `6.2.0`.