### PR TITLE
Bugfix - Remove even more touch delay

### DIFF
--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -43,6 +43,12 @@
         }
     });
 }
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  return TRUE;
+}
+
 @end
 
 
@@ -64,26 +70,10 @@ RCT_EXPORT_MODULE(RCTMGLMapView)
     RCTMGLMapView *mapView = [[RCTMGLMapView alloc] initWithFrame:RCT_MAPBOX_MIN_MAP_FRAME];
     mapView.delegate = self;
 
-    // setup map gesture recongizers
-    UIShortTapGestureRecognizer *doubleTap = [[UIShortTapGestureRecognizer alloc] initWithTarget:self action:nil];
-    doubleTap.numberOfTapsRequired = 2;
-
     UIShortTapGestureRecognizer *tap = [[UIShortTapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapMap:)];
-
-    [tap requireGestureRecognizerToFail:doubleTap];
 
     UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(didLongPressMap:)];
 
-    // this allows the internal annotation gestures to take precedents over the map tap gesture
-    for (int i = 0; i < mapView.gestureRecognizers.count; i++) {
-        UIGestureRecognizer *gestuerReconginer = mapView.gestureRecognizers[i];
-
-        if ([gestuerReconginer isKindOfClass:[UITapGestureRecognizer class]]) {
-            [tap requireGestureRecognizerToFail:gestuerReconginer];
-        }
-    }
-
-    [mapView addGestureRecognizer:doubleTap];
     [mapView addGestureRecognizer:tap];
     [mapView addGestureRecognizer:longPress];
 
@@ -105,7 +95,6 @@ RCT_REMAP_VIEW_PROPERTY(zoomEnabled, reactZoomEnabled, BOOL)
 
 RCT_REMAP_VIEW_PROPERTY(contentInset, reactContentInset, NSArray)
 RCT_REMAP_VIEW_PROPERTY(centerCoordinate, reactCenterCoordinate, NSString)
-RCT_REMAP_VIEW_PROPERTY(visibleCoordinateBounds, reactVisibleCoordinateBounds, NSString)
 RCT_REMAP_VIEW_PROPERTY(styleURL, reactStyleURL, NSString)
 
 RCT_REMAP_VIEW_PROPERTY(userTrackingMode, reactUserTrackingMode, int)

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -95,6 +95,7 @@ RCT_REMAP_VIEW_PROPERTY(zoomEnabled, reactZoomEnabled, BOOL)
 
 RCT_REMAP_VIEW_PROPERTY(contentInset, reactContentInset, NSArray)
 RCT_REMAP_VIEW_PROPERTY(centerCoordinate, reactCenterCoordinate, NSString)
+RCT_REMAP_VIEW_PROPERTY(visibleCoordinateBounds, reactVisibleCoordinateBounds, NSString)
 RCT_REMAP_VIEW_PROPERTY(styleURL, reactStyleURL, NSString)
 
 RCT_REMAP_VIEW_PROPERTY(userTrackingMode, reactUserTrackingMode, int)


### PR DESCRIPTION
This shortens the single tap delay to 200ms, by removing dependency on the other gestures from the mapbox, which are created by default. It doesn't really affect the functionality, aside from the double tap gesture, which might also invoke a single tap gesture. This is not a terribly bad tradeoff, since it's not uncommon for google maps to do this, as well as the fact that it's not really the gesture used to zoom in/out of the map.

Also removed double tap handler which wasn't doing anything, and just a no-op to avoid other touches from the native map touch.